### PR TITLE
Preact support

### DIFF
--- a/packages/number-flow/src/index.ts
+++ b/packages/number-flow/src/index.ts
@@ -49,7 +49,22 @@ let styleSheet: CSSStyleSheet | undefined
 // doesn't include things like attribute support:
 export class NumberFlowLite extends ServerSafeHTMLElement {
 	static define() {
-		if (BROWSER) customElements.define('number-flow', this)
+		if (BROWSER) {
+			const registeredElement = customElements.get('number-flow')
+
+			// If an element is already registered with the same name by another library, warn the user.
+			if (registeredElement && registeredElement.constructor !== this.constructor) {
+				console.error(
+					'An element has already been defined under the name `number-flow`. NumberFlow is not compatible in this case.'
+				)
+				return
+			}
+
+			// If the element is not registered, register it.
+			if (!registeredElement) {
+				customElements.define('number-flow', this)
+			}
+		}
 	}
 
 	transformTiming = defaultTransformTiming

--- a/packages/number-flow/src/index.ts
+++ b/packages/number-flow/src/index.ts
@@ -106,7 +106,9 @@ export class NumberFlowLite extends ServerSafeHTMLElement {
 			this.#parts = parts
 
 			// Don't check for declarative shadow DOM because we'll recreate it anyway:
-			this.attachShadow({ mode: 'open' })
+			if (!this.shadowRoot) {
+				this.attachShadow({ mode: 'open' })
+			}
 
 			// Add stylesheet
 			if (typeof CSSStyleSheet !== 'undefined' && this.shadowRoot!.adoptedStyleSheets) {


### PR DESCRIPTION
This fixes the 2 broken issues from #38

The Trend issue is due to preact rendering the component with serialized parts, so implementing the same fix for React19 will work. Unfortunately I can't find a way to tell if `preact` is in use. It might be necessary to provide another export `@number-flow/preact`, or add a prop, or rely on an env variable to change the behaviour