### PR TITLE
fix: number-flow-react already defined

### DIFF
--- a/packages/react/src/NumberFlow.tsx
+++ b/packages/react/src/NumberFlow.tsx
@@ -30,7 +30,9 @@ export class NumberFlowElement extends NumberFlowLite {
 	}
 }
 
-define('number-flow-react', NumberFlowElement)
+if (!customElements.get('number-flow-react')) {
+  define('number-flow-react', NumberFlowElement)
+}
 
 type BaseProps = React.HTMLAttributes<NumberFlowElement> &
 	Partial<Props> & {


### PR DESCRIPTION
This issue occurs when using react-flow/react with NextJS `const dynamic = 'force-static'`

it seems the web component is being registered twice due to how `force-static` renders components.

anyways it’s a small fix. I had to embed the source code (with my fix) in my project to get around the error for now