### PR TITLE
fix: hydration mismatch in Svelte 5

### DIFF
--- a/packages/number-flow/src/ssr.ts
+++ b/packages/number-flow/src/ssr.ts
@@ -39,8 +39,13 @@ const renderPart = (part: KeyedNumberPart) =>
 const renderSection = (section: KeyedNumberPart[], part: string) =>
 	`<span part="${part}">${section.reduce((str, p) => str + renderPart(p), '')}</span>`
 
+export const renderFallback = (data: Data) =>
+	html`<span
+		style="font-kerning: none; display: inline-block; line-height: ${charHeight} !important; padding: ${maskHeight} 0;"
+		>${data.valueAsString}</span
+	>`
+
 export const renderInnerHTML = (data: Data) =>
-	// shadowroot="open" non-standard attribute for old Chrome:
 	html`<template shadowroot="open" shadowrootmode="open"
 			><style>
 				${styles}</style
@@ -52,7 +57,4 @@ export const renderInnerHTML = (data: Data) =>
 					)}</span
 				>${renderSection(data.post, 'right')}</span
 			></template
-		><span
-			style="font-kerning: none; display: inline-block; line-height: ${charHeight} !important; padding: ${maskHeight} 0;"
-			>${data.valueAsString}</span
-		>` // ^ fallback for browsers that don't support DSD
+		>${renderFallback(data)}` // ^ fallback for browsers that don't support DSD

--- a/packages/svelte/src/lib/NumberFlow.svelte
+++ b/packages/svelte/src/lib/NumberFlow.svelte
@@ -34,7 +34,6 @@
 	import type { HTMLAttributes } from 'svelte/elements'
 	import { writable } from 'svelte/store'
 	import { getGroupContext } from './group.js'
-	import { BROWSER } from 'esm-env'
 
 	export let locales: Intl.LocalesArgument = undefined
 	export let format: Format | undefined = undefined
@@ -102,5 +101,5 @@
 	__svelte_digits={digits}
 	{data}
 >
-	{@html BROWSER ? undefined : renderInnerHTML(data)}
+	{@html renderInnerHTML(data)}
 </number-flow-svelte>


### PR DESCRIPTION
Solves https://github.com/barvian/number-flow/issues/109

Resolves hydration warnings by rendering consistent HTML on both server and client, and cleaning up DSD templates to prevent accumulation when frameworks re-use the same component, usually in SPA, custom routing or using view transitions.

This should pave the way to fix React and Vue as well, although my knowledge and testing scenarios are not quite there for them.