### PR TITLE
[codex] Guard DOM globals before custom element setup

### DIFF
--- a/packages/number-flow/src/ssr.ts
+++ b/packages/number-flow/src/ssr.ts
@@ -3,9 +3,10 @@ import { css, html } from './util/string'
 import { halfMaskHeight, maskHeight } from './styles'
 import { BROWSER } from 'esm-env'
 
-export const ServerSafeHTMLElement = BROWSER
-	? HTMLElement
-	: (class {} as unknown as typeof HTMLElement) // for types
+export const ServerSafeHTMLElement =
+	BROWSER && typeof HTMLElement !== 'undefined'
+		? HTMLElement
+		: (class {} as unknown as typeof HTMLElement) // for types
 
 export const styles = css`
 	:host {

--- a/packages/number-flow/src/util/dom.ts
+++ b/packages/number-flow/src/util/dom.ts
@@ -39,6 +39,11 @@ export const visible = (el: HTMLElement) => el.offsetWidth > 0 && el.offsetHeigh
 export const define = (name: string, constructor: CustomElementConstructor) => {
 	// Opt for the simpler check, the constructor check breaks in Next.js force-static,
 	// Svelte REPL, and Webpack Module Federation:
-	if (BROWSER && !customElements.get(name) /* !== constructor*/)
+	if (
+		BROWSER &&
+		typeof HTMLElement !== 'undefined' &&
+		typeof customElements !== 'undefined' &&
+		!customElements.get(name) /* !== constructor*/
+	)
 		customElements.define(name, constructor)
 }


### PR DESCRIPTION
## Summary

This fixes an SSR import-time crash when `number-flow` is evaluated in an environment that takes the browser build path, but does not actually expose browser DOM globals.

The specific failure mode is that `BROWSER` can be true while `HTMLElement` or `customElements` are still undefined. In that case the package currently crashes before user code gets a chance to do anything useful.

## What changed

- `ServerSafeHTMLElement` now checks that `HTMLElement` exists before extending it.
- `define()` now checks that both `HTMLElement` and `customElements` exist before registering the custom element.

In a real browser, behavior stays the same: the custom element still registers normally.

In SSR / worker-style runtimes without those DOM globals, the module can now be imported safely instead of throwing at module initialization time.

## Why this layer

This is intentionally fixed in `number-flow` itself rather than in a framework wrapper. The React/Vue/etc. packages import the core element code, so guarding only a wrapper would still leave the core package capable of crashing during import.
