### PR TITLE
perf: skip redundant layout measurement to avoid forced reflows

### DIFF
--- a/.changeset/lucky-donuts-shout.md
+++ b/.changeset/lucky-donuts-shout.md
@@ -1,0 +1,5 @@
+---
+'number-flow': patch
+---
+
+Avoid forced reflows from redundant layout measurement: skip identity-equal `data` re-sets (React 19 double-sets `data` on mount) and skip the `willUpdate` measurement pass when animations can't run

--- a/packages/number-flow/src/lite.ts
+++ b/packages/number-flow/src/lite.ts
@@ -126,6 +126,15 @@ export default class NumberFlowLite extends ServerSafeHTMLElement implements Pro
 			return
 		}
 
+		// Skip identity-equal re-sets. React 19 sets the `data` property during
+		// its commit, then the React wrapper's componentDidMount sets the same
+		// object again; without this check the second set takes the update path
+		// below and measures every section and digit, forcing a synchronous
+		// reflow per mounted element (barvian/number-flow#195):
+		if (data === this._data) {
+			return
+		}
+
 		const { pre, integer, fraction, post, value } = data
 
 		// Initialize if needed
@@ -199,11 +208,27 @@ export default class NumberFlowLite extends ServerSafeHTMLElement implements Pro
 		}
 	}
 
+	private _preUpdated = false
+
 	/**
 	 * @internal
 	 */
 	willUpdate() {
-		// Not super safe to check animated here, b/c the prop may not have been updated yet:
+		// Skip the measurement pass when animations can't run: it reads layout
+		// (a forced reflow) for every section and digit, and didUpdate — its only
+		// consumer — would discard the measurements anyway
+		// (barvian/number-flow#195). Only cheap checks here; `visible(this)`
+		// itself reads layout so it stays in `set data`. didUpdate also checks
+		// `_preUpdated`, so a prop that changes between the two passes degrades
+		// to skipping that animation rather than animating from missing
+		// measurements:
+		this._preUpdated =
+			canAnimate &&
+			this._animated &&
+			(!this.respectMotionPreference || !prefersReducedMotion?.matches) &&
+			this.ownerDocument.visibilityState === 'visible'
+		if (!this._preUpdated) return
+
 		this._pre!.willUpdate()
 		this._num!.willUpdate()
 		this._post!.willUpdate()
@@ -215,8 +240,9 @@ export default class NumberFlowLite extends ServerSafeHTMLElement implements Pro
 	 * @internal
 	 */
 	didUpdate() {
-		// Safe to call this here because we know the animated prop is up-to-date
-		if (!this.computedAnimated) return
+		// Safe to call this here because we know the animated prop is up-to-date.
+		// Also make sure willUpdate didn't skip its measurement pass:
+		if (!this.computedAnimated || !this._preUpdated) return
 
 		// If we're already animating, cancel the previous animationsfinish event:
 		if (this._abortAnimationsFinish) this._abortAnimationsFinish.abort()


### PR DESCRIPTION
Fixes #195

On a page with many `NumberFlow` elements (e.g. engagement counts on an x.com profile timeline), Chrome's "Forced reflow" insight attributed ~500 ms of forced synchronous layout to number-flow during load + scroll. Two redundant measurement paths in `NumberFlowLite` were responsible:

1. **Identity-equal `data` re-sets measure everything.** With React 19, React assigns the `data` property during its commit, and then the React wrapper's `componentDidMount` assigns the *same object* again (that second assignment is needed for the hydration path, where React doesn't assign properties). The second set takes the update path, which reads `offsetWidth`/`getBoundingClientRect` for every section and digit — so every element pays a forced reflow just by mounting, and virtualized lists remount elements constantly while scrolling. `set data` now bails when the incoming object is identity-equal to the current one, which is visually a no-op. The React <19 attribute path always parses a fresh object, so it can never be falsely deduped.

2. **`willUpdate` measures even when nothing will animate.** `didUpdate` — the only consumer of the measurements — already bails on `computedAnimated`, but the pre-update pass ran unconditionally, so `animated={false}` (or reduced motion / hidden document) elements still paid the layout reads on every value change. `willUpdate` now performs the same cheap checks that feed `computedAnimated` (`canAnimate`, `_animated`, motion preference, document visibility — deliberately *not* `visible(this)`, which itself reads layout) and records the result; `didUpdate` also checks that flag, so the previous "not super safe to check animated here" concern degrades to gracefully skipping one animation if a wrapper flips props between the two passes, rather than animating off missing measurements.

Verified with a jsdom harness counting `getBoundingClientRect` calls against the built `lite.mjs`:

| Scenario | before | after |
| --- | --- | --- |
| first `data` set (mount) | 0 | 0 |
| identity-equal `data` re-set (React 19 mount) | 8 | 0 |
| value update, `animated = false` | 16 | 0 |
| value update, `animated = true` | 16 | 16 |

In the app where this was found, the two changes (applied via a prototype-patch wrapper, plus viewport gating on `animated`) took the page from 2,382 forced layouts / 547.7 ms to 68 / 50.8 ms on the same load + scroll pass.

Note: I couldn't run the Playwright visual suites locally (browser download kept stalling on my network), so I'm relying on CI for those; the jsdom harness above covers the behavioral cases.

Made with [Cursor](https://cursor.com)